### PR TITLE
Preprod

### DIFF
--- a/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomFrameworkApi.php
+++ b/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomFrameworkApi.php
@@ -212,11 +212,12 @@ class CustomFrameworkApi
 
         // Retrieve the live framework data
         $framework = $frameworkRepository->findLiveFramework($rmNumber);
-        $frameworkData = $framework->toArray();
 
         if ($framework === false) {
             return new WP_Error('rest_invalid_param', 'framework not found', array('status' => 404));
         }
+
+        $frameworkData = $framework->toArray();
 
         $lotRepository = new LotRepository();
         //Retrieve all lots for a corresponding framework, based on the rm number

--- a/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomSupplierApi.php
+++ b/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomSupplierApi.php
@@ -100,7 +100,7 @@ class CustomSupplierApi
                 $frameworksData[$index] = $framework->toArray();
                 $lotsData = [];
 
-                // Find all lots for the retrieved frameworks and the curernt individual supplier
+                // Find all lots for the retrieved frameworks and the current individual supplier
                 $lots = $lotRepository->findAllByFrameworkIdSupplierId($framework->getSalesforceId(), $supplier->getSalesforceId());
 
                 if ($lots !== false) {

--- a/src/App/Repository/LotRepository.php
+++ b/src/App/Repository/LotRepository.php
@@ -211,6 +211,7 @@ JOIN ccs_lots l ON l.framework_id = f.salesforce_id
 JOIN ccs_lot_supplier ls ON ls.lot_id = l.salesforce_id
 WHERE f.salesforce_id = '$frameworkId'
 AND ls.supplier_id = '$supplierId'
+ORDER BY l.lot_number
 EOD;
         return $this->findAllLots($sql);
     }


### PR DESCRIPTION
This contains fixes for ticket CCS3-640 (ensuring frameworks and lots have consistent titles in WP)  and CCS3-636 (lots not appearing in the correct order) and a small change for the framework supplier data

