### PR TITLE
Preprod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ public/wp-content/blogs.dir/
 public/wp-content/cache/
 public/wp-content/upgrade/
 public/wp-content/uploads/
+
+# Account for the Revisionize plugin addons
+!public/wp-content/uploads/revisionize/addons/contributors_can.php
+
 public/wp-content/mu-plugins/
 public/wp-content/wp-cache-config.php
 public/wp-content/plugins/hello.php
@@ -30,3 +34,4 @@ vendor/*
 # Wordpress
 # Account for plugins that include a vendor directory but no composer.json file
 !public/wp-content/plugins/**/vendor
+

--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ Please see [further web documentation](https://github.com/Crown-Commercial-Servi
 
 ## Deployment
 
-The process for making new changes to the codebase is:
+### Testing changes
 
-1. Test in a feature branch
-2. Merge to `development` branch to test in Development environment
-3. Merge to `preprod` branch to test in PreProd (UAT) environment, get client to test and approve change
-4. When ready to go live create Pull Request to merge changes into `master`, once approved this will deploy to Production
+1. Test in a feature branch.
+2. Merge to `development` branch to test in Development environment.
+3. Merge to `preprod` branch to test in PreProd (UAT) environment.
+4. Get client to test and approve change.
+
+### Deploy a change to Production
+
+1. Create Pull Request to merge changes into `master`, ensure you add details of tickets you are fixing in the PR.
+2. Code must pass automatic tests & be approved by one other person.
+3. Email internal-it@crowncommercial.gov.uk to ask approval of this PR.
+4. Once approved, merge into master. This deploys to Production. 
 
 See details on [Environments](https://github.com/Crown-Commercial-Service/ccsweb-docs/blob/master/web/ENVIRONMENTS.md) (private docs).
 

--- a/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomFrameworkApi.php
+++ b/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomFrameworkApi.php
@@ -212,11 +212,12 @@ class CustomFrameworkApi
 
         // Retrieve the live framework data
         $framework = $frameworkRepository->findLiveFramework($rmNumber);
-        $frameworkData = $framework->toArray();
 
         if ($framework === false) {
             return new WP_Error('rest_invalid_param', 'framework not found', array('status' => 404));
         }
+
+        $frameworkData = $framework->toArray();
 
         $lotRepository = new LotRepository();
         //Retrieve all lots for a corresponding framework, based on the rm number

--- a/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomSupplierApi.php
+++ b/public/wp-content/plugins/ccs-salesforce/includes/wp-rest-api/CustomSupplierApi.php
@@ -100,7 +100,7 @@ class CustomSupplierApi
                 $frameworksData[$index] = $framework->toArray();
                 $lotsData = [];
 
-                // Find all lots for the retrieved frameworks and the curernt individual supplier
+                // Find all lots for the retrieved frameworks and the current individual supplier
                 $lots = $lotRepository->findAllByFrameworkIdSupplierId($framework->getSalesforceId(), $supplier->getSalesforceId());
 
                 if ($lots !== false) {

--- a/public/wp-content/uploads/revisionize/addons/contributors_can.php
+++ b/public/wp-content/uploads/revisionize/addons/contributors_can.php
@@ -1,0 +1,81 @@
+<?php
+
+class RevisionizeContributorsCan extends RevisionizeAddon {
+  function name() {
+    return 'contributors_can';
+  }
+
+  function version() {
+    return '1.0.1';
+  }
+
+  function init() {
+    add_action('admin_init', array($this, 'setup_settings'));
+    add_action('admin_enqueue_scripts', array($this, 'check_capabilities'));
+    add_action('admin_action_editpost', array($this, 'check_capabilities'));
+    add_filter('revisionize_is_create_enabled', array($this, 'is_create_enabled'), 10, 2);
+    add_filter('revisionize_show_dashboard_widget', array($this, 'filter_show_dashboard_widget'));
+  }
+
+  function is_create_enabled($is_enabled, $post) {
+    $is_enabled = $post->post_status == 'publish' && !\Revisionize\get_revision_of($post) && ($post->post_type=='page' && current_user_can('edit_pages') || $post->post_type!='page' && current_user_can('edit_posts'));
+    
+    if ($is_enabled && !current_user_can('edit_post', $post->ID)) {
+      $max = intval(\Revisionize\get_setting('max_revisions', 0));
+      if ($max > 0) {
+        // get number of revisions made for this post by this user. 
+        $revisions = get_posts(array(
+          'posts_per_page' => -1,
+          'author' => get_current_user_id(),
+          'meta_key' => '_post_revision_of',
+          'meta_value' => $post->ID,
+          'post_type' => 'any',
+          'post_status' => array('draft', 'pending'),
+        ));
+        $is_enabled = count($revisions) < $max;
+      }
+    }
+    return $is_enabled;
+  }  
+
+  function setup_settings() {
+    add_settings_section('revisionize_section_contributors', '', '__return_null', 'revisionize');
+
+    \Revisionize\input_setting('number', 'Maximum Revisions', 'max_revisions', "The maximum number of revisions contributors can make per post. 0 for unlimited.", 0, 'revisionize_section_contributors');
+  
+    \Revisionize\input_setting('checkbox', 'Show Dashboard Panel', 'show_dashboard_widget', "Show a dashboard panel that lists Revisionized posts that are pending review.", true, 'revisionize_section_contributors');    
+
+    add_action('revisionize_settings_fields', array($this, 'settings_fields'), 9);
+  }
+
+  function settings_fields() {
+    \Revisionize\do_fields_section('revisionize_section_contributors');
+  }
+
+  function filter_show_dashboard_widget($b) {
+    return \Revisionize\is_checkbox_checked('show_dashboard_widget', true);
+  }
+
+  // if the current user cannot edit the post it is revisioning, then don't 
+  // allow him to publish the revision.
+  function check_capabilities() {
+    global $post;
+
+    if (empty($post) && !empty($_REQUEST['post_ID'])) {
+      $post = get_post($_REQUEST['post_ID']);
+    }
+    if (!empty($post) && current_user_can('publish_post', $post->ID)) {
+      $parent = \Revisionize\get_parent_post($post);
+      if ($parent && !current_user_can('edit_post', $parent->ID)) {
+        add_filter('user_has_cap', array($this, 'remove_publish_capabilities'));      
+      }
+    }
+  }
+
+  function remove_publish_capabilities($caps) {
+    unset($caps['publish_posts']);
+    unset($caps['publish_pages']);
+    return $caps;
+  }
+}
+

--- a/src/App/Repository/LotRepository.php
+++ b/src/App/Repository/LotRepository.php
@@ -211,7 +211,7 @@ JOIN ccs_lots l ON l.framework_id = f.salesforce_id
 JOIN ccs_lot_supplier ls ON ls.lot_id = l.salesforce_id
 WHERE f.salesforce_id = '$frameworkId'
 AND ls.supplier_id = '$supplierId'
-ORDER BY l.lot_number
+ORDER BY cast(l.lot_number as unsigned)
 EOD;
         return $this->findAllLots($sql);
     }

--- a/src/App/Repository/LotRepository.php
+++ b/src/App/Repository/LotRepository.php
@@ -211,6 +211,7 @@ JOIN ccs_lots l ON l.framework_id = f.salesforce_id
 JOIN ccs_lot_supplier ls ON ls.lot_id = l.salesforce_id
 WHERE f.salesforce_id = '$frameworkId'
 AND ls.supplier_id = '$supplierId'
+ORDER BY l.lot_number
 EOD;
         return $this->findAllLots($sql);
     }


### PR DESCRIPTION
This contains fixes for ticket CCS3-640 (ensuring frameworks and lots have consistent titles in WP) and CCS3-636 (lots not appearing in the correct order), a small change for the framework supplier data, updates to the Readme file to provide more info for the deployment process and an extra add-on ("Contributors Can") for the Revisionize plugin to the Git repo so it persists between deployments