### PR TITLE
enable framework authors to revisionze their frameworks

### DIFF
--- a/public/wp-content/plugins/ccs-custom/library/user-roles-fix.php
+++ b/public/wp-content/plugins/ccs-custom/library/user-roles-fix.php
@@ -14,3 +14,22 @@ add_action('user_register', 'ccs_user_register');
 
 
 add_filter( 'members_remove_old_levels', '__return_false' );
+
+/**
+ * Allow Framework Author to revisionize any framework they are authoring, including published ones
+ */
+add_filter('revisionize_user_can_revisionize', 'ccs_allow_framework_authors', 10, 0);
+
+function ccs_allow_framework_authors(){
+    return current_user_can('edit_posts') || current_user_can('edit_pages') || current_user_can('edit_frameworks');
+}
+
+add_filter('revisionize_is_create_enabled', 'ccs_enable_framework_authors', 20, 2);
+
+function ccs_enable_framework_authors($is_enabled, $post) {
+    if ( current_user_can('edit_frameworks') ) {
+        return true;
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
See ticket #10119 in zendesk.
Framework authors can now revisionize their frameworks (including published ones) whilst not being able to edit posts or pages.