### PR TITLE
Hotfix/10201 duplicate revisions

### DIFF
--- a/public/wp-content/plugins/ccs-custom/ccs-custom.php
+++ b/public/wp-content/plugins/ccs-custom/ccs-custom.php
@@ -20,6 +20,7 @@ include('library/responsive-oembed-videos.php');
 include('library/image-sizes.php');
 include('library/headless-cms.php');
 include('library/options-page.php');
+include('library/custom-revisionise.php');
 //include('library/usersnap.php');
 
 // the following can be used to customise the registration email sent to new users

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -72,12 +72,21 @@ function hideRevisioniseButton($post) {
 
 	if (!isViableForRevisionise($post)) {
 		// Revision found, so remove the button.
-		remove_action('post_submitbox_start','Revisionize\post_button',200,0);
+
+		// Since the revisionize plugin adds the button by directly outputting to the page, we can't use remove_action. 
+		// Instead we've decided to strip it out via CSS.
+		?>
+		<style>
+			a[href*="revisionize_create"] {
+				display:none!important;
+			}
+		</style>
+		<?php
 	}
 
 }
 
-add_action('post_submitbox_start','hideRevisioniseButton',100,1);
+add_action('post_submitbox_start','hideRevisioniseButton',200,1);
 
 
 

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -11,17 +11,31 @@ function checkForRevisions($post) {
     ));
 
 	$rowcount = $wpdb->num_rows;
-
 	return ($rowcount > 0) ? true : false;
 
 }
 
+function isViableForRevisionise($post) {
+
+	// Disallow revisionise on archived posts.
+	if ($post->post_status == 'archived') { 
+		return false; 
+	}
+
+	// If post already has revisions, disable access.
+	if (checkForRevisions($post)) {
+		return false;
+	}
+
+	return true;
+
+}
 
 // Post row (on listing)
 
 function hideRevisioniseFromPostRow($actions, $post) {
 
-	if (checkForRevisions($post)) {
+	if (!isViableForRevisionise($post)) {
 
 		// Revision found, so remove the option.
 		if (isset($actions['create_revision'])) {
@@ -42,7 +56,7 @@ add_filter('post_row_actions', 'hideRevisioniseFromPostRow', 100, 2);
 
 function hideRevisioniseButton($post) {
 
-	if (checkForRevisions($post)) {
+	if (!isViableForRevisionise($post)) {
 		// Revision found, so remove the button.
 		remove_action('post_submitbox_start','Revisionize\post_button',200,0);
 	}
@@ -57,10 +71,9 @@ add_action('post_submitbox_start','hideRevisioniseButton',100,1);
 
 function hideRevisioniseAdminBar($admin_bar) {
 
-	$post = new StdClass;
-	$post->ID = get_the_ID();
+	$post = get_post();
 
-	if (checkForRevisions($post) ) {
+	if (!isViableForRevisionise($post) ) {
 		// Revision found, so remove the link
 		$admin_bar->remove_menu('revisionize');
 	}

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -1,0 +1,52 @@
+<?php
+
+// Hooks to remove revisionise options if a post already has a revision. Aims to solve issue where multiple revisions were leading to duplicate pages being published.
+
+function checkForRevisions($post) {
+
+	global $wpdb;
+
+    $check = $wpdb->get_results($wpdb->prepare("
+        SELECT * FROM ".$wpdb->base_prefix."posts WHERE post_status='draft' AND post_parent= %d", $post->ID
+    ));
+
+	$rowcount = $wpdb->num_rows;
+
+	return ($rowcount > 0) ? true : false;
+
+}
+
+
+// Post row (on listing)
+
+function hideRevisioniseFromPostRow($actions, $post) {
+
+	if (!checkForRevisions($post)) {
+		return $actions;
+	}
+
+	// Revision found, so remove the option.
+
+	unset($actions['create_revision']);
+	return $actions;
+}
+
+
+add_filter('post_row_actions', 'hideRevisioniseFromPostRow', 100, 2);
+
+
+
+// Post button.
+
+function hideRevisioniseButton($post) {
+
+	if (checkForRevisions($post)) {
+		// Revision found, so remove the button.
+		remove_action('post_submitbox_start','Revisionize\post_button',200,0);
+	}
+
+}
+
+add_action('post_submitbox_start','hideRevisioniseButton',100,1);
+
+

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -21,14 +21,13 @@ function checkForRevisions($post) {
 
 function hideRevisioniseFromPostRow($actions, $post) {
 
-	if (!checkForRevisions($post)) {
-		return $actions;
-	}
+	if (checkForRevisions($post)) {
 
-	// Revision found, so remove the option.
+		// Revision found, so remove the option.
+		if (isset($actions['create_revision'])) {
+			unset($actions['create_revision']);
+		}
 
-	if (isset($actions['create_revision'])) {
-		unset($actions['create_revision']);
 	}
 
 	return $actions;

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -8,7 +8,7 @@ function checkForRevisions($post) {
 	global $wpdb;
 
     $check = $wpdb->get_results($wpdb->prepare("
-        SELECT * FROM ".$wpdb->base_prefix."posts WHERE post_status='draft' AND post_parent= %d", $post->ID
+        SELECT * FROM ".$wpdb->base_prefix."posts WHERE (post_status='in-progress' Or post_status='draft' OR post_status='pending') AND post_parent= %d", $post->ID
     ));
 
 	$rowcount = $wpdb->num_rows;

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -27,7 +27,10 @@ function hideRevisioniseFromPostRow($actions, $post) {
 
 	// Revision found, so remove the option.
 
-	unset($actions['create_revision']);
+	if (isset($actions['create_revision'])) {
+		unset($actions['create_revision']);
+	}
+
 	return $actions;
 }
 
@@ -48,5 +51,23 @@ function hideRevisioniseButton($post) {
 }
 
 add_action('post_submitbox_start','hideRevisioniseButton',100,1);
+
+
+
+// Admin bar
+
+function hideRevisioniseAdminBar($admin_bar) {
+
+	$post = new StdClass;
+	$post->ID = get_the_ID();
+
+	if (checkForRevisions($post) ) {
+		// Revision found, so remove the link
+		$admin_bar->remove_menu('revisionize');
+	}
+	return $admin_bar;
+}
+
+add_action('admin_bar_menu','hideRevisioniseAdminBar',200,1);
 
 

--- a/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-revisionise.php
@@ -1,5 +1,6 @@
 <?php
-
+// Revisionise adjustments
+//
 // Hooks to remove revisionise options if a post already has a revision. Aims to solve issue where multiple revisions were leading to duplicate pages being published.
 
 function checkForRevisions($post) {
@@ -17,12 +18,23 @@ function checkForRevisions($post) {
 
 function isViableForRevisionise($post) {
 
+
 	// Disallow revisionise on archived posts.
 	if ($post->post_status == 'archived') { 
 		return false; 
 	}
 
-	// If post already has revisions, disable access.
+	// Disallow revisionise on pending posts.
+	if ($post->post_status == 'pending') { 
+		return false; 
+	}
+
+	// If post has a parent, and isn't published, remove option.
+	if ($post->post_parent > 0 && $post->post_status != 'publish') {
+		return false;
+	}
+
+	// If post already has revisions, disable revisionise option.
 	if (checkForRevisions($post)) {
 		return false;
 	}
@@ -30,6 +42,8 @@ function isViableForRevisionise($post) {
 	return true;
 
 }
+
+// Wordpress Hooks
 
 // Post row (on listing)
 
@@ -72,6 +86,10 @@ add_action('post_submitbox_start','hideRevisioniseButton',100,1);
 function hideRevisioniseAdminBar($admin_bar) {
 
 	$post = get_post();
+
+	if (!$post) { 
+		return $admin_bar; 
+	}
 
 	if (!isViableForRevisionise($post) ) {
 		// Revision found, so remove the link


### PR DESCRIPTION
I've added some hooks to try and clean up the WP navigation when it comes to adding revisionize links in the CMS. The code checks to see if a post has a revision already in progress, and attempts to hide revisionize buttons in response. This is to address an issue where multiple posts were appearing due to users creating multiple revisions of the same post.

Would appreciate if you guys could sanity-check this. If this looks good I might need to go further and remove revision options from pending, archive and draft posts too.