### PR TITLE
when filter for Energy, U&F will also show

### DIFF
--- a/public/search-api/frameworks.php
+++ b/public/search-api/frameworks.php
@@ -40,6 +40,14 @@ if (isset($_GET['category'])) {
       'condition' => 'AND',
       'value'     => $category
     ];
+
+    if ($category == "Energy"){
+        $filters['category'] = [
+            'field'     => 'category',
+            'condition' => 'OR',
+            'value'     => ["Energy", "Utilities & Fuels"]
+        ];
+    }
 }
 
 if (isset($_GET['status'])) {


### PR DESCRIPTION
This is a temporary solution while we are changing "Utilities & Fuels" to "Energy". This will ensure that all result will show when user are filter with the term "Energy".