### PR TITLE
Revert "when filter for Energy, U&F will also show"

### DIFF
--- a/public/search-api/frameworks.php
+++ b/public/search-api/frameworks.php
@@ -40,14 +40,6 @@ if (isset($_GET['category'])) {
       'condition' => 'AND',
       'value'     => $category
     ];
-
-    if ($category == "Energy"){
-        $filters['category'] = [
-            'field'     => 'category',
-            'condition' => 'OR',
-            'value'     => ["Energy", "Utilities & Fuels"]
-        ];
-    }
 }
 
 if (isset($_GET['status'])) {


### PR DESCRIPTION
Reverts Crown-Commercial-Service/ccs-wordpress#122
Remove unnecessary code when all of "Utilities & Fuels" are rename to "Energy"