### PR TITLE
change apache file request size to match max upload size on wordpress

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -40,7 +40,7 @@ Deny from all
 </IfModule>
 </Files>
 ServerSignature Off
-LimitRequestBody 10240000
+LimitRequestBody 20240000
 <Files wp-config.php>
 <IfModule mod_authz_core.c>
 Require all denied


### PR DESCRIPTION
This should fix the 'unexpected response error from server' issue when uploading the zip file. This changes the file request size on apache server from 10.24mb to 20.24mb.