### PR TITLE
Web 1471 stopwords reindexing using curl script

### DIFF
--- a/public/reindex_search.sh
+++ b/public/reindex_search.sh
@@ -2,26 +2,15 @@
 
 # reindexes elasticsearch
 
-# loads elastic suffix from .env file
+# loads elastic suffix and elastic endpoint from .env file
 ELASTIC_SUFFIX=$(grep ELASTIC_SUFFIX ../.env | xargs)
+ELASTIC_ENDPOINT=$(grep ELASTIC_ENDPOINT ../.env | xargs)
+
 IFS='=' read -ra ELASTIC_SUFFIX <<< "$ELASTIC_SUFFIX"
+IFS='=' read -ra ELASTIC_ENDPOINT <<< "$ELASTIC_ENDPOINT"
+
 ELASTIC_SUFFIX=${ELASTIC_SUFFIX[1]//$'\r'}
-
-if [[ $ELASTIC_SUFFIX == "local" ]]; then
-  ELASTIC_ENDPOINT="localhost:9200"
-fi
-
-if [[ $ELASTIC_SUFFIX == "dev" ]]; then
-  ELASTIC_ENDPOINT="https://vpc-elasticsearch-ccs-dev-wvwrvhqdfoxbuhcdft7bk33dta.eu-west-1.es.amazonaws.com"
-fi
-
-if [[ $ELASTIC_SUFFIX == "uat" ]]; then
-  ELASTIC_ENDPOINT="https://vpc-elasticsearch-ccs-uat-ebfgjzsrb2rdyxm6z3oy2mnohi.eu-west-2.es.amazonaws.com"
-fi
-
-if [[ $ELASTIC_SUFFIX == "prod" ]]; then
-  ELASTIC_ENDPOINT="https://vpc-elasticsearch-ccs-prod-eur4vilhtjrxeumhbeqevtkcvi.eu-west-2.es.amazonaws.com"
-fi
+ELASTIC_ENDPOINT=${ELASTIC_ENDPOINT[1]//$'\r'}
 
 echo "Reindexing Frameworks"
 curl -X PUT "${ELASTIC_ENDPOINT}/framework_${ELASTIC_SUFFIX}_temp?pretty" -H 'Content-Type: application/json' -d' {

--- a/public/reindex_search.sh
+++ b/public/reindex_search.sh
@@ -1,0 +1,457 @@
+#!/bin/bash
+
+# reindexes elasticsearch
+
+# loads elastic suffix from .env file
+ELASTIC_SUFFIX=$(grep ELASTIC_SUFFIX ../.env | xargs)
+IFS='=' read -ra ELASTIC_SUFFIX <<< "$ELASTIC_SUFFIX"
+ELASTIC_SUFFIX=${ELASTIC_SUFFIX[1]//$'\r'}
+
+if [[ $ELASTIC_SUFFIX == "local" ]]; then
+  ELASTIC_ENDPOINT="localhost:9200"
+fi
+
+if [[ $ELASTIC_SUFFIX == "dev" ]]; then
+  ELASTIC_ENDPOINT="https://vpc-elasticsearch-ccs-dev-wvwrvhqdfoxbuhcdft7bk33dta.eu-west-1.es.amazonaws.com"
+fi
+
+if [[ $ELASTIC_SUFFIX == "uat" ]]; then
+  ELASTIC_ENDPOINT="https://vpc-elasticsearch-ccs-uat-ebfgjzsrb2rdyxm6z3oy2mnohi.eu-west-2.es.amazonaws.com"
+fi
+
+if [[ $ELASTIC_SUFFIX == "prod" ]]; then
+  ELASTIC_ENDPOINT="https://vpc-elasticsearch-ccs-prod-eur4vilhtjrxeumhbeqevtkcvi.eu-west-2.es.amazonaws.com"
+fi
+
+echo "Reindexing Frameworks"
+curl -X PUT "${ELASTIC_ENDPOINT}/framework_${ELASTIC_SUFFIX}_temp?pretty" -H 'Content-Type: application/json' -d' {
+  "settings": {
+    "analysis": {
+      "filter": {
+        "english_stemmer": {
+          "name": "english",
+          "type": "stemmer"
+        },
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      },
+      "analyzer": {
+        "english_analyzer": {
+          "filter": [
+            "lowercase",
+            "english_stemmer",
+            "english_stop"
+          ],
+          "tokenizer": "standard"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "benefits": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "category": {
+        "type": "keyword"
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "end_date": {
+        "type": "date"
+      },
+      "how_to_buy": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "id": {
+        "type": "integer"
+      },
+      "keywords": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "lots": {
+        "type": "nested",
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "title": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pillar": {
+        "type": "keyword"
+      },
+      "published_status": {
+        "type": "keyword"
+      },
+      "rm_number": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        },
+        "fielddata": true
+      },
+      "rm_number_numerical": {
+        "type": "keyword"
+      },
+      "salesforce_id": {
+        "type": "keyword"
+      },
+      "start_date": {
+        "type": "date"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "summary": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "terms": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        },
+        "analyzer": "english_analyzer"
+      },
+      "type": {
+        "type": "keyword"
+      }
+    }
+  }
+} ' &&
+
+curl -X POST "${ELASTIC_ENDPOINT}/_reindex?pretty" -H 'Content-Type: application/json' -d' { "source": { "index": "framework_'${ELASTIC_SUFFIX}'" }, "dest": { "index": "framework_'${ELASTIC_SUFFIX}'_temp" } } ' &&
+
+curl -X DELETE "${ELASTIC_ENDPOINT}/framework_${ELASTIC_SUFFIX}?pretty" &&
+
+curl -X PUT "${ELASTIC_ENDPOINT}/framework_${ELASTIC_SUFFIX}?pretty" -H 'Content-Type: application/json' -d' {
+  "settings": {
+    "analysis": {
+      "filter": {
+        "english_stemmer": {
+          "name": "english",
+          "type": "stemmer"
+        },
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      },
+      "analyzer": {
+        "english_analyzer": {
+          "filter": [
+            "lowercase",
+            "english_stemmer",
+            "english_stop"
+          ],
+          "tokenizer": "standard"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "benefits": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "category": {
+        "type": "keyword"
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "end_date": {
+        "type": "date"
+      },
+      "how_to_buy": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "id": {
+        "type": "integer"
+      },
+      "keywords": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "lots": {
+        "type": "nested",
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "title": {
+            "type": "keyword"
+          }
+        }
+      },
+      "pillar": {
+        "type": "keyword"
+      },
+      "published_status": {
+        "type": "keyword"
+      },
+      "rm_number": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        },
+        "fielddata": true
+      },
+      "rm_number_numerical": {
+        "type": "keyword"
+      },
+      "salesforce_id": {
+        "type": "keyword"
+      },
+      "start_date": {
+        "type": "date"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "summary": {
+        "type": "text",
+        "analyzer": "english_analyzer"
+      },
+      "terms": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        },
+        "analyzer": "english_analyzer"
+      },
+      "type": {
+        "type": "keyword"
+      }
+    }
+  }
+} ' &&
+
+curl -X POST "${ELASTIC_ENDPOINT}/_reindex?pretty" -H 'Content-Type: application/json' -d' { "source": { "index": "framework_'${ELASTIC_SUFFIX}'_temp" }, "dest": { "index": "framework_'${ELASTIC_SUFFIX}'" } } ' &&
+
+curl -X DELETE "${ELASTIC_ENDPOINT}/framework_${ELASTIC_SUFFIX}_temp?pretty"
+
+echo "Reindexing Supplier"
+curl -X PUT "${ELASTIC_ENDPOINT}/supplier_${ELASTIC_SUFFIX}_temp?pretty" -H 'Content-Type: application/json' -d' {
+  "settings": {
+    "analysis": {
+      "filter": {
+        "english_stemmer": {
+          "name": "english",
+          "type": "stemmer"
+        },
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      },
+      "analyzer": {
+        "english_analyzer": {
+          "filter": [
+            "lowercase",
+            "english_stemmer",
+            "english_stop"
+          ],
+          "tokenizer": "standard"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "alternative_trading_names": {
+        "type": "text"
+      },
+      "city": {
+        "type": "text"
+      },
+      "duns_number": {
+        "type": "keyword"
+      },
+      "encoded_name": {
+        "type": "text"
+      },
+      "have_guarantor": {
+        "type": "boolean"
+      },
+      "id": {
+        "type": "integer"
+      },
+      "live_frameworks": {
+        "type": "nested",
+        "properties": {
+          "end_date": {
+            "type": "date"
+          },
+          "lot_ids": {
+            "type": "keyword"
+          },
+          "rm_number": {
+            "type": "text",
+            "fielddata": true
+          },
+          "rm_number_numerical": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          }
+        }
+      },
+      "name": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        },
+        "analyzer": "english_analyzer"
+      },
+      "postcode": {
+        "type": "text"
+      },
+      "salesforce_id": {
+        "type": "keyword"
+      },
+      "trading_name": {
+        "type": "text"
+      }
+    }
+  }
+} ' &&
+
+curl -X POST "${ELASTIC_ENDPOINT}/_reindex?pretty" -H 'Content-Type: application/json' -d' { "source": { "index": "supplier_'${ELASTIC_SUFFIX}'" }, "dest": { "index": "supplier_'${ELASTIC_SUFFIX}'_temp" } } ' &&
+
+curl -X DELETE "${ELASTIC_ENDPOINT}/supplier_${ELASTIC_SUFFIX}?pretty" &&
+
+curl -X PUT "${ELASTIC_ENDPOINT}/supplier_${ELASTIC_SUFFIX}?pretty" -H 'Content-Type: application/json' -d' {
+  "settings": {
+    "analysis": {
+      "filter": {
+        "english_stemmer": {
+          "name": "english",
+          "type": "stemmer"
+        },
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      },
+      "analyzer": {
+        "english_analyzer": {
+          "filter": [
+            "lowercase",
+            "english_stemmer",
+            "english_stop"
+          ],
+          "tokenizer": "standard"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "alternative_trading_names": {
+        "type": "text"
+      },
+      "city": {
+        "type": "text"
+      },
+      "duns_number": {
+        "type": "keyword"
+      },
+      "encoded_name": {
+        "type": "text"
+      },
+      "have_guarantor": {
+        "type": "boolean"
+      },
+      "id": {
+        "type": "integer"
+      },
+      "live_frameworks": {
+        "type": "nested",
+        "properties": {
+          "end_date": {
+            "type": "date"
+          },
+          "lot_ids": {
+            "type": "keyword"
+          },
+          "rm_number": {
+            "type": "text",
+            "fielddata": true
+          },
+          "rm_number_numerical": {
+            "type": "keyword"
+          },
+          "status": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          }
+        }
+      },
+      "name": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        },
+        "analyzer": "english_analyzer"
+      },
+      "postcode": {
+        "type": "text"
+      },
+      "salesforce_id": {
+        "type": "keyword"
+      },
+      "trading_name": {
+        "type": "text"
+      }
+    }
+  }
+} ' &&
+
+curl -X POST "${ELASTIC_ENDPOINT}/_reindex?pretty" -H 'Content-Type: application/json' -d'{"source": {"index": "supplier_'${ELASTIC_SUFFIX}'_temp"},"dest": {"index": "supplier_'${ELASTIC_SUFFIX}'"}}' &&
+
+curl -X DELETE "${ELASTIC_ENDPOINT}/supplier_${ELASTIC_SUFFIX}_temp?pretty"
+echo "Reindexing Complete"

--- a/src/App/Search/FrameworkSearchClient.php
+++ b/src/App/Search/FrameworkSearchClient.php
@@ -121,7 +121,7 @@ class FrameworkSearchClient extends AbstractSearchClient implements SearchClient
     {
         $search = new Search($this);
 
-        $search->addIndex($this->getIndexOrCreate());
+        $search->addIndex($this->getIndex($this->getQualifiedIndexName()));
 
         // Create a bool query to allow us to set up multiple query types
         $boolQuery = new Query\BoolQuery();

--- a/src/App/Search/SupplierSearchClient.php
+++ b/src/App/Search/SupplierSearchClient.php
@@ -134,7 +134,7 @@ class SupplierSearchClient extends AbstractSearchClient implements SearchClientI
     {
         $search = new Search($this);
 
-        $search->addIndex($this->getIndexOrCreate());
+        $search->addIndex($this->getIndex($this->getQualifiedIndexName()));
 
         // Create a bool query to allow us to set up multiple query types
         $boolQuery = new Query\BoolQuery();


### PR DESCRIPTION
This PR adds a bash shell script which can be called by doing the following:
- Using the terminal cd into ccs-wordpress/public folder
- call script by running this command: `./reindex_search.sh `

The script does the following:
- Loads variable from .env file : ELASTIC_SUFFIX so that this can be used in the script
- checks environment and adjusts ELASTIC_ENDPOINT url accordingly to access elasticsearch server

The reindexing does the following for each index: framework and supplier:
- Creates a new temporary index to copy data into
- Copies data from old index into to new temp index using the reindex api command
- deletes old index
- creates a new index with same name as old index
- copies data from temp index to new index (with same name as old index)
- deletes temp index

I can test this on dev by accessing the devbox, however UAT and Prod will need to be done by techops. 

P.S I also need to modify FrameworkSearchClient and SupplierSearchClient as this was what was causing the issue on dev with 0 agreements showing up. It would basically create a new index if it didn't exist. Running this alongside reindexing caused the reindexing to not work properly hence the need to change the code. 