### PR TITLE
Web 1488 add new digital brochure post type to replicate whitepapers

### DIFF
--- a/public/wp-content/plugins/ccs-custom/library/custom-excerpts-descriptions.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-excerpts-descriptions.php
@@ -12,7 +12,7 @@ function update_excerpt_metas( $translation, $original ) {
 		return $translation;
 	}
 
-	if ( $post->post_type == 'whitepaper' || $post->post_type == 'webinar' ) {
+	if ( $post->post_type == 'whitepaper' || $post->post_type == 'webinar' || $post->post_type == 'digital_brochure' ) {
 
 		if ( 'Excerpt' == $original ) {
 			//Change here to what you want Excerpt box to be called

--- a/public/wp-content/plugins/ccs-custom/library/custom-post-types.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-post-types.php
@@ -165,7 +165,7 @@ function ccs_register_my_cpts() {
 
     register_post_type( "whitepaper", $args) ;
 
-
+    
 
     // Whitepaper(s) content type
     $labels = array(
@@ -249,4 +249,47 @@ function ccs_register_my_cpts() {
     );
 
     register_post_type( "event", $args) ;
+
+
+
+
+    // Digital Brochure(s) content type
+    $labels = array(
+        "name" => __('Digital Brochures', ''),
+        "singular_name" => __('Digital Brochure', ''),
+        "menu_name" => __('Digital Brochures', ''),
+        "name_admin_bar" => __('Digital Brochures', ''),
+        'add_new'            => __('Add New', 'Digital Brochure', ''),
+        'add_new_item'       => __('Add New Digital Brochure', ''),
+        'new_item'           => __('New Digital Brochure', ''),
+        'edit_item'          => __('Edit Digital Brochure', ''),
+        'view_item'          => __('View Digital Brochure', ''),
+        'all_items'          => __('All Digital Brochures', ''),
+        'search_items'       => __('Search Digital Brochures', ''),
+        'parent_item_colon'  => __('Parent Digital Brochure:', ''),
+        'not_found'          => __('No Digital Brochures found.', ''),
+        'not_found_in_trash' => __('No Digital Brochures found in Trash.', '')
+    );
+
+    $args = array(
+        "labels" => $labels,
+        "description" => "",
+        "public" => true,
+        "publicly_queryable" => true,
+        "show_ui" => true,
+        "show_in_rest" => true,
+        "rest_base" => "",
+        "has_archive" => true,
+        "show_in_menu" => true,
+        "exclude_from_search" => false,
+        "capability_type" => "whitepaper",
+        "map_meta_cap" => true,
+        "hierarchical" => false,
+        "rewrite" => array("slug" => "digital-brochure"),
+        "query_var" => true,
+        "menu_icon" => "dashicons-welcome-learn-more",
+        "supports" => array("title", "revisions", "thumbnail"),
+    );
+
+    register_post_type( "digital_brochure", $args) ;
 }

--- a/public/wp-content/plugins/ccs-custom/library/custom-post-types.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-post-types.php
@@ -208,6 +208,45 @@ function ccs_register_my_cpts() {
     register_post_type( "webinar", $args) ;
 
 
+    // Digital Brochure(s) content type
+    $labels = array(
+        "name" => __('Digital Brochures', ''),
+        "singular_name" => __('Digital Brochure', ''),
+        "menu_name" => __('Digital Brochures', ''),
+        "name_admin_bar" => __('Digital Brochures', ''),
+        'add_new'            => __('Add New', 'Digital Brochure', ''),
+        'add_new_item'       => __('Add New Digital Brochure', ''),
+        'new_item'           => __('New Digital Brochure', ''),
+        'edit_item'          => __('Edit Digital Brochure', ''),
+        'view_item'          => __('View Digital Brochure', ''),
+        'all_items'          => __('All Digital Brochures', ''),
+        'search_items'       => __('Search Digital Brochures', ''),
+        'parent_item_colon'  => __('Parent Digital Brochure:', ''),
+        'not_found'          => __('No Digital Brochures found.', ''),
+        'not_found_in_trash' => __('No Digital Brochures found in Trash.', '')
+    );
+
+    $args = array(
+        "labels" => $labels,
+        "description" => "",
+        "public" => true,
+        "publicly_queryable" => true,
+        "show_ui" => true,
+        "show_in_rest" => true,
+        "rest_base" => "",
+        "has_archive" => true,
+        "show_in_menu" => true,
+        "exclude_from_search" => false,
+        "capability_type" => "whitepaper",
+        "map_meta_cap" => true,
+        "hierarchical" => false,
+        "rewrite" => array("slug" => "digital-brochure"),
+        "query_var" => true,
+        "menu_icon" => "dashicons-media-document",
+        "supports" => array("title", "revisions", "thumbnail"),
+    );
+
+    register_post_type( "digital_brochure", $args) ;
 
 
     // Event(s) content type
@@ -249,47 +288,4 @@ function ccs_register_my_cpts() {
     );
 
     register_post_type( "event", $args) ;
-
-
-
-
-    // Digital Brochure(s) content type
-    $labels = array(
-        "name" => __('Digital Brochures', ''),
-        "singular_name" => __('Digital Brochure', ''),
-        "menu_name" => __('Digital Brochures', ''),
-        "name_admin_bar" => __('Digital Brochures', ''),
-        'add_new'            => __('Add New', 'Digital Brochure', ''),
-        'add_new_item'       => __('Add New Digital Brochure', ''),
-        'new_item'           => __('New Digital Brochure', ''),
-        'edit_item'          => __('Edit Digital Brochure', ''),
-        'view_item'          => __('View Digital Brochure', ''),
-        'all_items'          => __('All Digital Brochures', ''),
-        'search_items'       => __('Search Digital Brochures', ''),
-        'parent_item_colon'  => __('Parent Digital Brochure:', ''),
-        'not_found'          => __('No Digital Brochures found.', ''),
-        'not_found_in_trash' => __('No Digital Brochures found in Trash.', '')
-    );
-
-    $args = array(
-        "labels" => $labels,
-        "description" => "",
-        "public" => true,
-        "publicly_queryable" => true,
-        "show_ui" => true,
-        "show_in_rest" => true,
-        "rest_base" => "",
-        "has_archive" => true,
-        "show_in_menu" => true,
-        "exclude_from_search" => false,
-        "capability_type" => "whitepaper",
-        "map_meta_cap" => true,
-        "hierarchical" => false,
-        "rewrite" => array("slug" => "digital-brochure"),
-        "query_var" => true,
-        "menu_icon" => "dashicons-welcome-learn-more",
-        "supports" => array("title", "revisions", "thumbnail"),
-    );
-
-    register_post_type( "digital_brochure", $args) ;
 }

--- a/public/wp-content/plugins/ccs-custom/library/custom-taxonomies.php
+++ b/public/wp-content/plugins/ccs-custom/library/custom-taxonomies.php
@@ -104,6 +104,7 @@ function register_pillars_taxonomy() {
 	register_taxonomy( 'pillars', array(
 		'page',
 		'whitepaper',
+		'digital_brochure',
 		'webinar'
 	), $args );
 	// We'll use this to make sure post types are attached inside filter callback that run during parse_request or pre_get_posts

--- a/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
+++ b/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
@@ -23,7 +23,7 @@ if (!function_exists('digital_brochures_add_data')) {
             $linkText = get_field('link_text', $postId);
 
             $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_brochure_file = $file;
-            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_brochure_image = ($featuredImageId != "" ? intval($featuredImageId) : null);
+            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_brochure_featured_image = ($featuredImageId != "" ? intval($featuredImageId) : null);
             $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->link_text = $linkText;
         }
 

--- a/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
+++ b/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
@@ -23,7 +23,7 @@ if (!function_exists('digital_brochures_add_data')) {
             $linkText = get_field('link_text', $postId);
 
             $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_brochure_file = $file;
-            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_borchure_image = ($featuredImageId != "" ? intval($featuredImageId) : null);
+            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_brochure_image = ($featuredImageId != "" ? intval($featuredImageId) : null);
             $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->link_text = $linkText;
         }
 

--- a/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
+++ b/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Modify the digital brochures relationship field that is returned on relevant
+ * pages so that it includes fields we need (featured image and digital brochure file)
+ */
+if (!function_exists('digital_brochures_add_data')) {
+    function digital_brochures_add_data($response, $post) {
+        if(!isset($response->data['acf']['digital_brochures_list_digital_brochures']) || empty($response->data['acf']['digital_brochures_list_digital_brochures'])) {
+            return $response;
+        }
+
+        foreach($response->data['acf']['digital_brochures_list_digital_brochures'] as $key => $whitepaper) {
+            if(!isset($whitepaper->ID)) {
+                continue;
+            }
+
+            $postId = $whitepaper->ID;
+
+            $file = get_field('digital_brochure_file', $postId);
+
+            $featuredImageId = get_post_thumbnail_id( $postId );
+            $linkText = get_field('link_text', $postId);
+
+            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_brochure_file = $file;
+            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->ccs_digital_borchure_image = ($featuredImageId != "" ? intval($featuredImageId) : null);
+            $response->data['acf']['digital_brochures_list_digital_brochures'][$key]->link_text = $linkText;
+        }
+
+        return $response;
+    }
+}
+
+
+add_filter('rest_prepare_page', 'digital_brochures_add_data', 10, 3);

--- a/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
+++ b/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-digital-brochures.php
@@ -10,12 +10,12 @@ if (!function_exists('digital_brochures_add_data')) {
             return $response;
         }
 
-        foreach($response->data['acf']['digital_brochures_list_digital_brochures'] as $key => $whitepaper) {
-            if(!isset($whitepaper->ID)) {
+        foreach($response->data['acf']['digital_brochures_list_digital_brochures'] as $key => $digital_brochure) {
+            if(!isset($digital_brochure->ID)) {
                 continue;
             }
 
-            $postId = $whitepaper->ID;
+            $postId = $digital_brochure->ID;
 
             $file = get_field('digital_brochure_file', $postId);
 

--- a/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-modifications.php
+++ b/public/wp-content/plugins/ccs-custom/library/rest-api/rest-api-modifications.php
@@ -49,3 +49,4 @@ require('rest-api-whitepapers.php');
 require('rest-api-webinars.php');
 require('rest-api-featured-news.php');
 require('rest-api-featured-events.php');
+require('rest-api-digital-brochures.php');

--- a/public/wp-content/plugins/ccs-custom/library/theme-support.php
+++ b/public/wp-content/plugins/ccs-custom/library/theme-support.php
@@ -16,7 +16,7 @@ function s24_add_description_to_featured_image_metabox($content, $post_id, $thum
 {
 	$post = get_post($post_id);
 
-	if ( $post->post_type == 'webinar' || $post->post_type == 'whitepaper' ) {
+	if ( $post->post_type == 'webinar' || $post->post_type == 'whitepaper' || $post->post_type == 'digital_brochure' ) {
 		$content .= '<small><em>Minimum size: 640&times;427. Recommended size: 1280&times;854.</em></small>';
 		return $content;
 	}

--- a/public/wp-content/plugins/fewbricks_definitions/bricks/digital-brochures-list.php
+++ b/public/wp-content/plugins/fewbricks_definitions/bricks/digital-brochures-list.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace fewbricks\bricks;
+
+use fewbricks\acf\fields as acf_fields;
+
+/**
+ * Class digital_brochures_list
+ * @package fewbricks\bricks
+ */
+class digital_brochures_list extends project_brick {
+
+    /**
+     * @var string This will be the default label showing up in the editor area for the administrator.
+     * It can be overridden by passing an item with the key "label" in the array that is the second argument when
+     * creating a brick.
+     */
+    protected $label = 'Digital Brochures List';
+
+    /**
+     * This is where all the fields for the brick will be set-
+     */
+    public function set_fields() {
+
+        $this->add_field( (new acf_fields\relationship('Digital Brochures', 'digital_brochures', '202103299533a', [
+            'post_type' => 'digital_brochure'
+        ])) );
+
+    }
+
+}

--- a/public/wp-content/plugins/fewbricks_definitions/field-groups/field-groups.php
+++ b/public/wp-content/plugins/fewbricks_definitions/field-groups/field-groups.php
@@ -15,6 +15,7 @@ include('post-types/supplier.php');
 include('post-types/whitepaper.php');
 include('post-types/webinar.php');
 include('post-types/event.php');
+include('post-types/digital-brochure.php');
 
 
 

--- a/public/wp-content/plugins/fewbricks_definitions/field-groups/post-types/digital-brochure.php
+++ b/public/wp-content/plugins/fewbricks_definitions/field-groups/post-types/digital-brochure.php
@@ -22,7 +22,13 @@ $fg1 = ( new fewacf\field_group( 'Digital Brochure Details', '202103293819a', $l
     ]
 ]));
 
-$fg1->add_field( new acf_fields\file( 'Digital Brochure', 'digital_brochure_file', '202103291846a' ) );
+$fg1->add_field( new acf_fields\text( 'Digital Brochure URL', 'digital_brochure_url', '202103301985a', [
+    'instructions' => 'URL to be displayed on confirmation page'
+] ) );
+
+$fg1->add_field( new acf_fields\text( 'Digital Brochure URL Text', 'digital_brochure_url_text', '202103301654a' ) );
+
+$fg1->add_field( new acf_fields\file( 'Digital Brochure File', 'digital_brochure_file', '202103291846a' ) );
 
 $fg1->add_field( new acf_fields\wysiwyg( 'Digital Brochure Form Introduction', 'form_introduction', '202103297695a', [
     'instructions' => 'Optional text to display above the form when requesting access to the Digital Brochure'

--- a/public/wp-content/plugins/fewbricks_definitions/field-groups/post-types/digital-brochure.php
+++ b/public/wp-content/plugins/fewbricks_definitions/field-groups/post-types/digital-brochure.php
@@ -1,0 +1,44 @@
+<?php
+use fewbricks\bricks AS bricks;
+use fewbricks\acf AS fewacf;
+use fewbricks\acf\fields AS acf_fields;
+
+
+// --- Setting up fields for the digital brochure custom post type ---
+
+$location = [
+    [
+        [
+            'param' => 'post_type',
+            'operator' => '==',
+            'value' => 'digital_brochure'
+        ]
+    ]
+];
+
+$fg1 = ( new fewacf\field_group( 'Digital Brochure Details', '202103293819a', $location, 10, [
+    'names_of_items_to_hide_on_screen' => [
+        'the_content'
+    ]
+]));
+
+$fg1->add_field( new acf_fields\file( 'Digital Brochure', 'digital_brochure_file', '202103291846a' ) );
+
+$fg1->add_field( new acf_fields\wysiwyg( 'Digital Brochure Form Introduction', 'form_introduction', '202103297695a', [
+    'instructions' => 'Optional text to display above the form when requesting access to the Digital Brochure'
+] ) );
+
+$fg1->add_field( new acf_fields\text( 'Link text', 'link_text', '202103294610a', [
+    'instructions' => 'Optionally add link text to display underneath the Digital Brochure when listing it.'
+] ) );
+
+$fg1->add_field( new acf_fields\text( 'Description', 'description', '202103290739a', [
+    'instructions' => 'This hidden description is sent to Salesforce when the form is submitted.'
+] ) );
+
+$fg1->add_field( new acf_fields\text( 'Campaign code', 'campaign_code', '202103292266a', [
+    'instructions' => 'An optional campaign code which will be sent to Salesforce on submission.'
+] ) );
+
+$fg1->register();
+

--- a/public/wp-content/plugins/fewbricks_definitions/field-groups/templates/landing.php
+++ b/public/wp-content/plugins/fewbricks_definitions/field-groups/templates/landing.php
@@ -81,6 +81,7 @@ $field_group->add_brick((new bricks\resources_intro('resources_intro', '20200110
 $field_group->add_brick((new bricks\brochures_list('brochures_list', '202001101634a')));
 $field_group->add_brick((new bricks\whitepapers_list('whitepapers_list', '202001131114a')));
 $field_group->add_brick((new bricks\webinars_list('webinars_list', '202001131712a')));
+$field_group->add_brick((new bricks\digital_brochures_list('digital_brochures_list', '202103291085a')));
 
 /*
  * Register the field group

--- a/public/wp-content/themes/ccs/functions.php
+++ b/public/wp-content/themes/ccs/functions.php
@@ -322,7 +322,9 @@ require get_template_directory() . '/inc/template-tags.php';
  */
 require get_template_directory() . '/inc/customizer.php';
 
-add_post_type_support( 'whitepaper', 'excerpt' ); 
+add_post_type_support( 'whitepaper', 'excerpt' );
+
+add_post_type_support( 'digital_brochure', 'excerpt' );
 
 function removing_post_tag_from_taxonomy_list(){
     register_taxonomy('post_tag', array());


### PR DESCRIPTION
Works similar to whitepapers feature except with added URL on confirmation page. 

To test:

- Go to wordpress and add new 'Digital Brochure' located in the admin menu on the left
- Fill in fields and publish
- Go to any page and add digital brochure (located under page resources metabox on page)
- Digital Brochure should appear on frontend page similar to whitepaper