### PR TITLE
update supplier analyzer to match framework analyzer

### DIFF
--- a/public/reindex_search.sh
+++ b/public/reindex_search.sh
@@ -266,6 +266,7 @@ curl -X PUT "${ELASTIC_ENDPOINT}/supplier_${ELASTIC_SUFFIX}_temp?pretty" -H 'Con
           "type": "stemmer"
         },
         "english_stop": {
+          "type": "stop",
           "stopwords_path": "analyzers/'${ELASTIC_STOPWORDS_ID}'",
           "updateable": true
         }


### PR DESCRIPTION
Supplier analyzer was missing 'type': 'stop' meaning supplier search wasn't adding stopwords properly this should hopefully fix that