### PR TITLE
remove user exist check for password reset

### DIFF
--- a/public/wp-content/plugins/all-in-one-wp-security-and-firewall/other-includes/wp-security-rename-login-feature.php
+++ b/public/wp-content/plugins/all-in-one-wp-security-and-firewall/other-includes/wp-security-rename-login-feature.php
@@ -1014,7 +1014,7 @@ switch ( $action ) {
 				'confirm',
 				sprintf(
 					/* translators: %s: Link to the login page. */
-					__( 'Check your email for the confirmation link, then visit the <a href="%s">login page</a>.' ),
+					__( 'If you are a valid user, please check your email for the confirmation link, then visit the <a href="%s">login page</a>.' ),
 					wp_login_url()
 				),
 				'message'

--- a/public/wp-includes/user.php
+++ b/public/wp-includes/user.php
@@ -2879,9 +2879,6 @@ function retrieve_password( $user_login = null ) {
 		$errors->add( 'empty_username', __( '<strong>Error</strong>: Please enter a username or email address.' ) );
 	} elseif ( strpos( $user_login, '@' ) ) {
 		$user_data = get_user_by( 'email', trim( wp_unslash( $user_login ) ) );
-		if ( empty( $user_data ) ) {
-			$errors->add( 'invalid_email', __( '<strong>Error</strong>: There is no account with that username or email address.' ) );
-		}
 	} else {
 		$user_data = get_user_by( 'login', trim( wp_unslash( $user_login ) ) );
 	}
@@ -2933,99 +2930,96 @@ function retrieve_password( $user_login = null ) {
 		return $errors;
 	}
 
-	if ( ! $user_data ) {
-		$errors->add( 'invalidcombo', __( '<strong>Error</strong>: There is no account with that username or email address.' ) );
-		return $errors;
-	}
+	if ($user_data != false){
+		// Redefining user_login ensures we return the right case in the email.
+		$user_login = $user_data->user_login;
+		$user_email = $user_data->user_email;
+		$key        = get_password_reset_key( $user_data );
 
-	// Redefining user_login ensures we return the right case in the email.
-	$user_login = $user_data->user_login;
-	$user_email = $user_data->user_email;
-	$key        = get_password_reset_key( $user_data );
-
-	if ( is_wp_error( $key ) ) {
-		return $key;
-	}
-
-	// Localize password reset message content for user.
-	$locale = get_user_locale( $user_data );
-
-	$switched_locale = switch_to_locale( $locale );
-
-	if ( is_multisite() ) {
-		$site_name = get_network()->site_name;
-	} else {
-		/*
-		 * The blogname option is escaped with esc_html on the way into the database
-		 * in sanitize_option. We want to reverse this for the plain text arena of emails.
-		 */
-		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-	}
-
-	$message = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
-	/* translators: %s: Site name. */
-	$message .= sprintf( __( 'Site Name: %s' ), $site_name ) . "\r\n\r\n";
-	/* translators: %s: User login. */
-	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
-	$message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
-	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . '&wp_lang=' . $locale . "\r\n\r\n";
-
-	if ( ! is_user_logged_in() ) {
-		$requester_ip = $_SERVER['REMOTE_ADDR'];
-		if ( $requester_ip ) {
-			$message .= sprintf(
-				/* translators: %s: IP address of password reset requester. */
-				__( 'This password reset request originated from the IP address %s.' ),
-				$requester_ip
-			) . "\r\n";
+		if ( is_wp_error( $key ) ) {
+			return $key;
 		}
-	}
 
-	/* translators: Password reset notification email subject. %s: Site title. */
-	$title = sprintf( __( '[%s] Password Reset' ), $site_name );
+		// Localize password reset message content for user.
+		$locale = get_user_locale( $user_data );
 
-	/**
-	 * Filters the subject of the password reset email.
-	 *
-	 * @since 2.8.0
-	 * @since 4.4.0 Added the `$user_login` and `$user_data` parameters.
-	 *
-	 * @param string  $title      Email subject.
-	 * @param string  $user_login The username for the user.
-	 * @param WP_User $user_data  WP_User object.
-	 */
-	$title = apply_filters( 'retrieve_password_title', $title, $user_login, $user_data );
+		$switched_locale = switch_to_locale( $locale );
 
-	/**
-	 * Filters the message body of the password reset mail.
-	 *
-	 * If the filtered message is empty, the password reset email will not be sent.
-	 *
-	 * @since 2.8.0
-	 * @since 4.1.0 Added `$user_login` and `$user_data` parameters.
-	 *
-	 * @param string  $message    Email message.
-	 * @param string  $key        The activation key.
-	 * @param string  $user_login The username for the user.
-	 * @param WP_User $user_data  WP_User object.
-	 */
-	$message = apply_filters( 'retrieve_password_message', $message, $key, $user_login, $user_data );
+		if ( is_multisite() ) {
+			$site_name = get_network()->site_name;
+		} else {
+			/*
+			* The blogname option is escaped with esc_html on the way into the database
+			* in sanitize_option. We want to reverse this for the plain text arena of emails.
+			*/
+			$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+		}
 
-	if ( $switched_locale ) {
-		restore_previous_locale();
-	}
+		$message = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
+		/* translators: %s: Site name. */
+		$message .= sprintf( __( 'Site Name: %s' ), $site_name ) . "\r\n\r\n";
+		/* translators: %s: User login. */
+		$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
+		$message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
+		$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
+		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . '&wp_lang=' . $locale . "\r\n\r\n";
 
-	if ( $message && ! wp_mail( $user_email, wp_specialchars_decode( $title ), $message ) ) {
-		$errors->add(
-			'retrieve_password_email_failure',
-			sprintf(
-				/* translators: %s: Documentation URL. */
-				__( '<strong>Error</strong>: The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' ),
-				esc_url( __( 'https://wordpress.org/support/article/resetting-your-password/' ) )
-			)
-		);
-		return $errors;
+		if ( ! is_user_logged_in() ) {
+			$requester_ip = $_SERVER['REMOTE_ADDR'];
+			if ( $requester_ip ) {
+				$message .= sprintf(
+					/* translators: %s: IP address of password reset requester. */
+					__( 'This password reset request originated from the IP address %s.' ),
+					$requester_ip
+				) . "\r\n";
+			}
+		}
+
+		/* translators: Password reset notification email subject. %s: Site title. */
+		$title = sprintf( __( '[%s] Password Reset' ), $site_name );
+
+		/**
+		 * Filters the subject of the password reset email.
+		 *
+		 * @since 2.8.0
+		 * @since 4.4.0 Added the `$user_login` and `$user_data` parameters.
+		 *
+		 * @param string  $title      Email subject.
+		 * @param string  $user_login The username for the user.
+		 * @param WP_User $user_data  WP_User object.
+		 */
+		$title = apply_filters( 'retrieve_password_title', $title, $user_login, $user_data );
+
+		/**
+		 * Filters the message body of the password reset mail.
+		 *
+		 * If the filtered message is empty, the password reset email will not be sent.
+		 *
+		 * @since 2.8.0
+		 * @since 4.1.0 Added `$user_login` and `$user_data` parameters.
+		 *
+		 * @param string  $message    Email message.
+		 * @param string  $key        The activation key.
+		 * @param string  $user_login The username for the user.
+		 * @param WP_User $user_data  WP_User object.
+		 */
+		$message = apply_filters( 'retrieve_password_message', $message, $key, $user_login, $user_data );
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+
+		if ( $message && ! wp_mail( $user_email, wp_specialchars_decode( $title ), $message ) ) {
+			$errors->add(
+				'retrieve_password_email_failure',
+				sprintf(
+					/* translators: %s: Documentation URL. */
+					__( '<strong>Error</strong>: The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' ),
+					esc_url( __( 'https://wordpress.org/support/article/resetting-your-password/' ) )
+				)
+			);
+			return $errors;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Removed the error message from the screenshot below so that it doesn't indicate if a user exists or not.
![Screenshot 2022-04-13 at 2 31 18 pm](https://user-images.githubusercontent.com/58430495/163192115-da8e6ff3-e7aa-4cad-99fa-d9c0463d4ba3.png)
