### PR TITLE
Installing Crontab for AL2023 AMI

### DIFF
--- a/deploy/server_setup.sh
+++ b/deploy/server_setup.sh
@@ -118,6 +118,11 @@ if [ ! -e "$FIRST_RUN_PATH" ]; then
     if [ "$APPLICATION_NAME" == "$IMPORT_APP_NAME" ]; then
         echo "> Installing import-specific wp_import process..."
 
+        echo "> Installing cronie..."
+        sudo yum install cronie -y
+        sudo systemctl enable crond.service
+        sudo systemctl start crond.service
+
         echo "> > chown'ing wp_import.sh..."
         sudo chown ec2-user:ec2-user "$SCRIPTDIR/$DEPLOYMENT_TYPE/files/wp_import.sh"
 


### PR DESCRIPTION
Cronie service is not installed as default on Amazon Linux 2023 as it was with Amazon Linux 2, but is still available to install

https://docs.aws.amazon.com/linux/al2023/ug/deprecated-al2023.html#deprecated-cron