### PR TITLE
Installing Standard Linux Logging for AL2023 AMI

### DIFF
--- a/deploy/server_setup.sh
+++ b/deploy/server_setup.sh
@@ -123,6 +123,11 @@ if [ ! -e "$FIRST_RUN_PATH" ]; then
         sudo systemctl enable crond.service
         sudo systemctl start crond.service
 
+        echo "> Installing text logging..."
+        sudo yum install rsyslog -y
+        sudo systemctl start rsyslog
+        sudo systemctl enable rsyslog
+
         echo "> > chown'ing wp_import.sh..."
         sudo chown ec2-user:ec2-user "$SCRIPTDIR/$DEPLOYMENT_TYPE/files/wp_import.sh"
 


### PR DESCRIPTION
AL2023 differs in its logging approach from standard linux and AL2, this will re-enable standard logging that we are using for deadmans snitch

ref: https://repost.aws/questions/QUQY6hp9bSQFK2bKNZ8rzDAQ/unable-to-locatate-syslog-and-messages-in-var-log